### PR TITLE
Add Safe keyboard detector for android

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [SSL public key pinning](#ssl-pinning)
 - [Certificate transparency](#certificate-transparency)
 - [Prevent "recent screenshots"](#prevent-recent-screenshots)
+- [Safe Keyboard Detector](#safe-keyboard-detector)
 
 > **⚠️ Disclaimer**<br/>
 > This package is intended to help implement a few basic security features but does not in itself guarantee that an app is secure.<br/>
@@ -125,9 +126,29 @@ Mitigating this threat is achieved by:
 ]
 ```
 
+## Safe Keyboard Detector
+
+> **🥷 What's the threat?** A third-party keyboard might embed a malicious keylogger to record passwords and sensitive data. [More details](https://www.synopsys.com/blogs/software-security/mitigate-third-party-mobile-keyboard-risk.html)
+
+Mitigating this threat is achieved by:
+
+- On Android, comparing the current keyboard id with a list of [keyboard packages that we deem safe](./android/src/main/java/tech/bam/rnas/RNASModule.kt#31).
+- On iOS, doing nothing specific since iOS already prevent the use of third-party keyboard on sensitive fields such as passwords.
+
+```tsx
+import { SafeKeyboardDetector } from '@bam.tech/react-native-app-security';
+
+const isCurrentKeyboardSafe = SafeKeyboardDetector.isCurrentKeyboardSafe() // will always return true on iOS
+
+// Prompt the user to change the current keyboard
+SafeKeyboardDetector.showInputMethodPicker() // can only be called on Android
+```
+
 # Contributing
 
 Contributions are welcome. See the [Expo modules docs](https://docs.expo.dev/modules/get-started/) for information on how to build/run/develop on the project.
+
+When making a change to the `plugin` folder, you'll need to run `yarn build` before prebuilding and building the example app.
 
 # 👉 About BAM
 

--- a/android/src/main/java/tech/bam/rnas/RNASModule.kt
+++ b/android/src/main/java/tech/bam/rnas/RNASModule.kt
@@ -2,9 +2,57 @@ package tech.bam.rnas
 
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import android.content.Context
+import android.view.inputmethod.InputMethodManager
+import android.provider.Settings
+
 
 class RNASModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("RNAS")
+
+    Function("showInputMethodPicker") {
+      val inputMethodManager = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+      inputMethodManager.showInputMethodPicker()
+    }
+
+
+    Function("isCurrentKeyboardSafe") { customPackagesList: Array<String>? ->
+      val currentKeyboardId =
+        Settings.Secure.getString(context.contentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+
+      return@Function isKeyboardSafe(currentKeyboardId, customPackagesList)
+    }
   }
+  private val context
+  get() = requireNotNull(appContext.reactContext)
+}
+
+val defaultAllowedKeyboardPackagesList = arrayOf("com.touchtype.swiftkey", "com.samsung.android", "com.google.android")
+
+
+/**
+ * Check whether the package name provided as `input` matches any of the allowed packages
+
+ * Examples:
+ * Input: com.myPackage.android.latin/id
+ * Array: ['com.myPackage.android']
+ * Output: true
+ *
+ * Input: android.com.myPackage.android.latin/id
+ * Array: ['com.myPackage.android']
+ * Output: false
+ *
+ * Input: com.randomPackage/com.myPackage.android.latin
+ * Array: ['com.myPackage.android']
+ * Output: false
+ */
+fun doesPackageNameMatch(input: String, allowedPackagesList: Array<String>): Boolean {
+  val packageName = input.substringBefore('/')
+  return allowedPackagesList.any { packageName.matches("${Regex.escape(it)}.*".toRegex()) }
+}
+
+fun isKeyboardSafe(keyboardID: String, customAllowedKeyboardPackagesList: Array<String>? = defaultAllowedKeyboardPackagesList): Boolean {
+  val allowedPackagesList = customAllowedKeyboardPackagesList ?: defaultAllowedKeyboardPackagesList
+  return doesPackageNameMatch(keyboardID, allowedPackagesList)
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Button, Modal, StyleSheet, View } from "react-native";
+import { SafeKeyboardDetector } from "@bam.tech/react-native-app-security";
 
 export default function App() {
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -17,6 +18,8 @@ export default function App() {
       <Button title="open modal" onPress={() => setIsModalVisible(true)} />
       <Button title="fetch - valid certificates" onPress={fetchValid} />
       <Button title="fetch - invalid certificates" onPress={fetchInvalid} />
+      <Button title="Is current keyboard safe?" onPress={checkIsKeyboardSafe} />
+      <Button title="show keyboard picker" onPress={showInputMethodPicker} />
     </View>
   );
 }
@@ -56,5 +59,18 @@ const fetchInvalid = async () => {
     });
   } catch (error) {
     console.warn("✅ invalid certificate and fetch failed", error);
+  }
+};
+
+const checkIsKeyboardSafe = () => {
+  const isKeyboardSafe = SafeKeyboardDetector.isCurrentKeyboardSafe();
+  console.warn("is Keyboard safe", isKeyboardSafe);
+};
+
+const showInputMethodPicker = () => {
+  try {
+    SafeKeyboardDetector.showInputMethodPicker();
+  } catch (error) {
+    console.warn("showInputMethodPicker threw. Did you call it on iOS?", error);
   }
 };

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -447,7 +447,7 @@ PODS:
     - React-jsi (= 0.72.6)
     - React-logger (= 0.72.6)
     - React-perflogger (= 0.72.6)
-  - RNAS (0.1.1):
+  - RNAS (0.1.3):
     - ExpoModulesCore
     - TrustKit (~> 3.0.3)
   - SocketRocket (0.6.1)
@@ -661,11 +661,11 @@ SPEC CHECKSUMS:
   React-runtimescheduler: f23e337008403341177fc52ee4ca94e442c17ede
   React-utils: fa59c9a3375fb6f4aeb66714fd3f7f76b43a9f16
   ReactCommon: dd03c17275c200496f346af93a7b94c53f3093a4
-  RNAS: 9b977ccebdd5e07aa5286251885d808baaf1eaea
+  RNAS: 6ee0db1ee999e6cbb05d476b1bfbcb0313f09036
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   TrustKit: 7858ea59d0e226b1457b2e9cc8b95d77ab21d471
   Yoga: b76f1acfda8212aa16b7e26bcce3983230c82603
 
 PODFILE CHECKSUM: 6daa8bab0f91b52da2001d6b9f17878279fbf1a9
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.13.0

--- a/example/ios/reactnativeappsecurityexample.xcodeproj/project.pbxproj
+++ b/example/ios/reactnativeappsecurityexample.xcodeproj/project.pbxproj
@@ -7,27 +7,27 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		057D9169AD3F49318AA27304 /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 657B304E93CD465EA8FBA77D /* noop-file.swift */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
 		96905EF65AED1B983A6B3ABC /* libPods-reactnativeappsecurityexample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-reactnativeappsecurityexample.a */; };
-		9C312102E4654C58A52F2D9A /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF78828B1CC41A48D3F458E /* noop-file.swift */; };
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		0EF78828B1CC41A48D3F458E /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "reactnativeappsecurityexample/noop-file.swift"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* reactnativeappsecurityexample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = reactnativeappsecurityexample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = reactnativeappsecurityexample/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = reactnativeappsecurityexample/AppDelegate.mm; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = reactnativeappsecurityexample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = reactnativeappsecurityexample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = reactnativeappsecurityexample/main.m; sourceTree = "<group>"; };
+		2DCC5C34B65B430C9D23848F /* reactnativeappsecurityexample-Bridging-Header.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; name = "reactnativeappsecurityexample-Bridging-Header.h"; path = "reactnativeappsecurityexample/reactnativeappsecurityexample-Bridging-Header.h"; sourceTree = "<group>"; };
 		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-reactnativeappsecurityexample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-reactnativeappsecurityexample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		657B304E93CD465EA8FBA77D /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "reactnativeappsecurityexample/noop-file.swift"; sourceTree = "<group>"; };
 		6C2E3173556A471DD304B334 /* Pods-reactnativeappsecurityexample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnativeappsecurityexample.debug.xcconfig"; path = "Target Support Files/Pods-reactnativeappsecurityexample/Pods-reactnativeappsecurityexample.debug.xcconfig"; sourceTree = "<group>"; };
-		6FFFA5F664574FBABA0E4F06 /* reactnativeappsecurityexample-Bridging-Header.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; name = "reactnativeappsecurityexample-Bridging-Header.h"; path = "reactnativeappsecurityexample/reactnativeappsecurityexample-Bridging-Header.h"; sourceTree = "<group>"; };
 		7A4D352CD337FB3A3BF06240 /* Pods-reactnativeappsecurityexample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnativeappsecurityexample.release.xcconfig"; path = "Target Support Files/Pods-reactnativeappsecurityexample/Pods-reactnativeappsecurityexample.release.xcconfig"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = reactnativeappsecurityexample/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
@@ -57,8 +57,8 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB71A68108700A75B9A /* main.m */,
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
-				0EF78828B1CC41A48D3F458E /* noop-file.swift */,
-				6FFFA5F664574FBABA0E4F06 /* reactnativeappsecurityexample-Bridging-Header.h */,
+				657B304E93CD465EA8FBA77D /* noop-file.swift */,
+				2DCC5C34B65B430C9D23848F /* reactnativeappsecurityexample-Bridging-Header.h */,
 			);
 			name = reactnativeappsecurityexample;
 			sourceTree = "<group>";
@@ -145,13 +145,13 @@
 			buildPhases = (
 				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
-				A76648976B5E4C1BC1D596C0 /* [Expo] Configure project */,
+				AA0019DBEFC1BD061A006FDD /* [Expo] Configure project */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
-				207FB40296F78CAFC68D7563 /* [CP] Embed Pods Frameworks */,
+				43091AD653F59D5941B8CE0E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -243,7 +243,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		207FB40296F78CAFC68D7563 /* [CP] Embed Pods Frameworks */ = {
+		43091AD653F59D5941B8CE0E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -281,7 +281,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-reactnativeappsecurityexample/Pods-reactnativeappsecurityexample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A76648976B5E4C1BC1D596C0 /* [Expo] Configure project */ = {
+		AA0019DBEFC1BD061A006FDD /* [Expo] Configure project */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -329,7 +329,7 @@
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */,
-				9C312102E4654C58A52F2D9A /* noop-file.swift in Sources */,
+				057D9169AD3F49318AA27304 /* noop-file.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -360,7 +360,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = tech.bam.rnas.example;
-				PRODUCT_NAME = "reactnativeappsecurityexample";
+				PRODUCT_NAME = reactnativeappsecurityexample;
 				SWIFT_OBJC_BRIDGING_HEADER = "reactnativeappsecurityexample/reactnativeappsecurityexample-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -388,7 +388,7 @@
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = tech.bam.rnas.example;
-				PRODUCT_NAME = "reactnativeappsecurityexample";
+				PRODUCT_NAME = reactnativeappsecurityexample;
 				SWIFT_OBJC_BRIDGING_HEADER = "reactnativeappsecurityexample/reactnativeappsecurityexample-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/RNASModule.swift
+++ b/ios/RNASModule.swift
@@ -3,6 +3,18 @@ import ExpoModulesCore
 public class RNASModule: Module {
   public func definition() -> ModuleDefinition {
     Name("RNAS")
-    // There's nothing here because we use TrustKit's "auto-setup" via the config in `Info.plist`
+    // There's nothing here related to SSL pinning because we use TrustKit's "auto-setup" via the config in `Info.plist`
+    
+    Function("showInputMethodPicker") {() in
+          throw RNASModuleError.methodNotImplemented
+        }
+
+    Function("isCurrentKeyboardSafe") {() in
+          return true
+    }
   }
+}
+
+enum RNASModuleError: Error {
+    case methodNotImplemented
 }

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,7 +1,7 @@
 import { ConfigPlugin } from "@expo/config-plugins";
-import withSSLPinning from "./withSSLPinning";
-import withpreventRecentScreenshots from "./withPreventRecentScreenshots";
 import { RNASConfig } from "./types";
+import withpreventRecentScreenshots from "./withPreventRecentScreenshots";
+import withSSLPinning from "./withSSLPinning";
 
 const withRNAS: ConfigPlugin<RNASConfig> = (config, props) => {
   config = withSSLPinning(config, props.sslPinning);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,7 @@
-// No JS API for now, but without this file expo plugin resolution fails
+import RNASModule from "./RNASModule";
+import { SafeKeyboardDetectorInterface } from "./types";
+
+export const SafeKeyboardDetector: SafeKeyboardDetectorInterface = {
+  isCurrentKeyboardSafe: RNASModule.isCurrentKeyboardSafe,
+  showInputMethodPicker: RNASModule.showInputMethodPicker,
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,17 @@
+export type SafeKeyboardDetectorInterface ={
+  /**
+   * Compare the current keyboard package name with a list of safe keyboard package names on Android
+   * Will always return true on iOS
+   *
+   * @param customAllowedKeyboardList a list keyboard package names. If not provided, a default list is used.
+   *
+   * @example
+   * const isSafe = isCurrentKeyboardSafe(["com.touchtype.swiftkey", "com.samsung.android", "com.google.android"])
+   */
+  isCurrentKeyboardSafe: (customAllowedKeyboardList?: string[]) => boolean;
+  /**
+   * Prompt the user to change his current keyboard to a safe one.
+   * Will throw an error if used on iOS
+   */
+  showInputMethodPicker: () => void;
+}


### PR DESCRIPTION
**Why third-party keyboards are a threat:** 
Third-party keyboards might embed malicious keyloggers to record passwords and sensitive data.

**Our proposition**
We've established a whiteListedKeyboardList based on empirical tests + documentation.
The SafeKeyboardDetector object exposes 2 methods : 
- isCurrentKeyboardSafe :  check if the currently used keyboard matches one of the whiteListed keyboards or not.
- showInputMethodPicker: show Android native pop-up to change the selected keyboard.
