### PR TITLE
Add exception description for showInputMethodPicker method on iOS

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { Button, Modal, StyleSheet, View } from "react-native";
 import { SafeKeyboardDetector } from "@bam.tech/react-native-app-security";
+import { useState } from "react";
+import { Button, Modal, Platform, StyleSheet, View } from "react-native";
 
 export default function App() {
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -19,7 +19,12 @@ export default function App() {
       <Button title="fetch - valid certificates" onPress={fetchValid} />
       <Button title="fetch - invalid certificates" onPress={fetchInvalid} />
       <Button title="Is current keyboard safe?" onPress={checkIsKeyboardSafe} />
-      <Button title="show keyboard picker" onPress={showInputMethodPicker} />
+      {Platform.OS === "android" ? (
+        <Button
+          title="show keyboard picker"
+          onPress={() => SafeKeyboardDetector.showInputMethodPicker()}
+        />
+      ) : null}
     </View>
   );
 }
@@ -65,12 +70,4 @@ const fetchInvalid = async () => {
 const checkIsKeyboardSafe = () => {
   const isKeyboardSafe = SafeKeyboardDetector.isCurrentKeyboardSafe();
   console.warn("is Keyboard safe", isKeyboardSafe);
-};
-
-const showInputMethodPicker = () => {
-  try {
-    SafeKeyboardDetector.showInputMethodPicker();
-  } catch (error) {
-    console.warn("showInputMethodPicker threw. Did you call it on iOS?", error);
-  }
 };

--- a/ios/RNASModule.swift
+++ b/ios/RNASModule.swift
@@ -6,7 +6,7 @@ public class RNASModule: Module {
     // There's nothing here related to SSL pinning because we use TrustKit's "auto-setup" via the config in `Info.plist`
     
     Function("showInputMethodPicker") {() in
-          throw RNASModuleError.methodNotImplemented
+          throw InputMethodPickerUnavailableException()
         }
 
     Function("isCurrentKeyboardSafe") {() in
@@ -15,6 +15,9 @@ public class RNASModule: Module {
   }
 }
 
-enum RNASModuleError: Error {
-    case methodNotImplemented
+
+internal class InputMethodPickerUnavailableException: Exception {
+  override var reason: String {
+    return "Method not implemented on iOS since third-party keyboards security issues are not relevant on iOS."
+  }
 }


### PR DESCRIPTION
Improve error stack trace by adding an exception description

<img width="1285" alt="image" src="https://github.com/bamlab/react-native-app-security/assets/89008469/88b58cfe-d207-4714-a32a-1f0fe0907871">