### PR TITLE
Breaking change/return input method

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,15 @@ Mitigating this threat is achieved by:
 - On iOS, doing nothing specific since iOS already prevent the use of third-party keyboard on sensitive fields such as passwords.
 
 ```tsx
-import { SafeKeyboardDetector } from '@bam.tech/react-native-app-security';
+import { SafeKeyboardDetector } from "@bam.tech/react-native-app-security";
 
-const isCurrentKeyboardSafe = SafeKeyboardDetector.isCurrentKeyboardSafe() // will always return true on iOS
+const { isInDefaultSafeList, inputMethodId } = getCurrentInputMethodInfo(); // Will always return {isInDefaultSafeList: true, inputMethodId: "iosKeyboard"} on iOS
+if (!isInDefaultSafeList) {
+  console.warn(`Your current keyboard (${inputMethodId}) is not safe`);
+}
 
 // Prompt the user to change the current keyboard
-SafeKeyboardDetector.showInputMethodPicker() // can only be called on Android
+SafeKeyboardDetector.showInputMethodPicker(); // can only be called on Android
 ```
 
 # Contributing

--- a/android/src/main/java/tech/bam/rnas/RNASModule.kt
+++ b/android/src/main/java/tech/bam/rnas/RNASModule.kt
@@ -17,11 +17,15 @@ class RNASModule : Module() {
     }
 
 
-    Function("isCurrentKeyboardSafe") { customPackagesList: Array<String>? ->
+    Function("getCurrentInputMethodInfo") {
       val currentKeyboardId =
         Settings.Secure.getString(context.contentResolver, Settings.Secure.DEFAULT_INPUT_METHOD)
+      val isInDefaultSafeList = isKeyboardSafe(currentKeyboardId)
 
-      return@Function isKeyboardSafe(currentKeyboardId, customPackagesList)
+      return@Function mapOf(
+        "isInDefaultSafeList" to isInDefaultSafeList,
+        "inputMethodId" to currentKeyboardId.substringBefore('/')
+      )
     }
   }
   private val context
@@ -52,7 +56,6 @@ fun doesPackageNameMatch(input: String, allowedPackagesList: Array<String>): Boo
   return allowedPackagesList.any { packageName.matches("${Regex.escape(it)}.*".toRegex()) }
 }
 
-fun isKeyboardSafe(keyboardID: String, customAllowedKeyboardPackagesList: Array<String>? = defaultAllowedKeyboardPackagesList): Boolean {
-  val allowedPackagesList = customAllowedKeyboardPackagesList ?: defaultAllowedKeyboardPackagesList
-  return doesPackageNameMatch(keyboardID, allowedPackagesList)
+fun isKeyboardSafe(keyboardID: String): Boolean {
+  return doesPackageNameMatch(keyboardID, defaultAllowedKeyboardPackagesList)
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -68,6 +68,8 @@ const fetchInvalid = async () => {
 };
 
 const checkIsKeyboardSafe = () => {
-  const isKeyboardSafe = SafeKeyboardDetector.isCurrentKeyboardSafe();
+  const isKeyboardSafe =
+    SafeKeyboardDetector.getCurrentInputMethodInfo().isInDefaultSafeList;
+  console.log(SafeKeyboardDetector.getCurrentInputMethodInfo().inputMethodId);
   console.warn("is Keyboard safe", isKeyboardSafe);
 };

--- a/ios/RNASModule.swift
+++ b/ios/RNASModule.swift
@@ -10,7 +10,7 @@ public class RNASModule: Module {
         }
 
     Function("getCurrentInputMethodInfo") {() in
-          return ["isInDefaultSafeList": true, "inputMethodId": ""]
+          return ["isInDefaultSafeList": true, "inputMethodId": "iosKeyboard"]
     }
   }
 }

--- a/ios/RNASModule.swift
+++ b/ios/RNASModule.swift
@@ -9,11 +9,13 @@ public class RNASModule: Module {
           throw InputMethodPickerUnavailableException()
         }
 
-    Function("isCurrentKeyboardSafe") {() in
-          return true
+    Function("getCurrentInputMethodInfo") {() in
+          return ["isInDefaultSafeList": true, "inputMethodId": ""]
     }
   }
 }
+
+
 
 
 internal class InputMethodPickerUnavailableException: Exception {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ import RNASModule from "./RNASModule";
 import { SafeKeyboardDetectorInterface } from "./types";
 
 export const SafeKeyboardDetector: SafeKeyboardDetectorInterface = {
-  isCurrentKeyboardSafe: RNASModule.isCurrentKeyboardSafe,
   showInputMethodPicker: RNASModule.showInputMethodPicker,
+  getCurrentInputMethodInfo: RNASModule.getCurrentInputMethodInfo,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export type SafeKeyboardDetectorInterface = {
   /**
    * Compare the current keyboard package name with a list of default safe keyboard package names on Android
-   * Will always return true on iOS
+   * Will always return {isInDefaultSafeList: true, inputMethodId: ""} on iOS
    *
    * @example
    * const { isInDefaultSafeList, inputMethodId } = getCurrentInputMethodInfo();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 export type SafeKeyboardDetectorInterface = {
   /**
    * Compare the current keyboard package name with a list of default safe keyboard package names on Android
-   * Will always return {isInDefaultSafeList: true, inputMethodId: ""} on iOS
+   * Will always return {isInDefaultSafeList: true, inputMethodId: "iosKeyboard"} on iOS
    *
    * @example
    * const { isInDefaultSafeList, inputMethodId } = getCurrentInputMethodInfo();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,17 +1,21 @@
-export type SafeKeyboardDetectorInterface ={
+export type SafeKeyboardDetectorInterface = {
   /**
-   * Compare the current keyboard package name with a list of safe keyboard package names on Android
+   * Compare the current keyboard package name with a list of default safe keyboard package names on Android
    * Will always return true on iOS
    *
-   * @param customAllowedKeyboardList a list keyboard package names. If not provided, a default list is used.
-   *
    * @example
-   * const isSafe = isCurrentKeyboardSafe(["com.touchtype.swiftkey", "com.samsung.android", "com.google.android"])
+   * const { isInDefaultSafeList, inputMethodId } = getCurrentInputMethodInfo();
+   * if (!isInDefaultSafeList) {
+   *  console.warn(`Your current keyboard (${inputMethodId}) is not safe`);
+   * }
    */
-  isCurrentKeyboardSafe: (customAllowedKeyboardList?: string[]) => boolean;
+  getCurrentInputMethodInfo: () => {
+    isInDefaultSafeList: boolean;
+    inputMethodId: string;
+  };
   /**
    * Prompt the user to change his current keyboard to a safe one.
    * Will throw an error if used on iOS
    */
   showInputMethodPicker: () => void;
-}
+};


### PR DESCRIPTION
As we would like to be able to retrieve the id of the used keyboard, we change the isCurrentKeyboardSafe method to getCurrentInputMethodInfo.

The new method retrieves the id of the used keyboard, along with a safety verification (comparison with the three main keyboards currently used).