### PR TITLE
Support wildcard subdomains pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,30 @@ This package implements [public key pinning](https://cheatsheetseries.owasp.org/
 ]
 ```
 
-Please note that you'll need to provide *2* public key hashes. This is to encourage having proper procedures in place to avoid locking users out, [as described here in the TrustKit docs](https://github.com/datatheorem/TrustKit/blob/master/docs/getting-started.md#always-provide-at-least-one-backup-pin).
+Please note that you'll need to provide _2_ public key hashes. This is to encourage having proper procedures in place to avoid locking users out, [as described here in the TrustKit docs](https://github.com/datatheorem/TrustKit/blob/master/docs/getting-started.md#always-provide-at-least-one-backup-pin).
+
+#### Pinning subdomains
+
+To pin a specific subdomain, simply include it in the string you provide, eg:
+
+```jsonc
+    "sslPinning": {
+      "subdomain.domain.com": [/* ... */]
+    }
+```
+
+To pin a domain and all its subdomains, use a wildcard:
+
+```jsonc
+    "sslPinning": {
+      // domain.com and all its subdomains will be pinned
+      "*.domain.com": [/* ... */]
+    }
+```
+
+> The wildcard can only be used for the full lefmost part of the hostname.
+>
+> These are invalid: `*domain.com`, `domain.*.com`, `sub.*.domain.com`
 
 ### Generating the public key hashes
 
@@ -153,7 +176,7 @@ SafeKeyboardDetector.showInputMethodPicker(); // can only be called on Android
 
 Contributions are welcome. See the [Expo modules docs](https://docs.expo.dev/modules/get-started/) for information on how to build/run/develop on the project.
 
-When making a change to the `plugin` folder, you'll need to run `yarn build` before prebuilding and building the example app.
+When making a change to the `plugin` folder, you'll need to run `yarn prepare` before prebuilding and building the example app.
 
 # 👉 About BAM
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -18,6 +18,10 @@ export default function App() {
       <Button title="open modal" onPress={() => setIsModalVisible(true)} />
       <Button title="fetch - valid certificates" onPress={fetchValid} />
       <Button title="fetch - invalid certificates" onPress={fetchInvalid} />
+      <Button
+        title="fetch - invalid certificates - subdodmain"
+        onPress={fetchInvalidSubdomain}
+      />
       <Button title="Is current keyboard safe?" onPress={checkIsKeyboardSafe} />
       {Platform.OS === "android" ? (
         <Button
@@ -59,6 +63,17 @@ const fetchValid = async () => {
 const fetchInvalid = async () => {
   try {
     const response = await fetch("https://yahoo.com");
+    console.warn("❌ invalid certificated but fetch succeeded", {
+      status: response.status,
+    });
+  } catch (error) {
+    console.warn("✅ invalid certificate and fetch failed", error);
+  }
+};
+
+const fetchInvalidSubdomain = async () => {
+  try {
+    const response = await fetch("https://login.yahoo.com");
     console.warn("❌ invalid certificated but fetch succeeded", {
       status: response.status,
     });

--- a/example/app.json
+++ b/example/app.json
@@ -30,7 +30,7 @@
         "../app.plugin.js",
         {
           "sslPinning": {
-            "yahoo.com": [
+            "*.yahoo.com": [
               "TQEtdMbmwFgYUifM4LDF+xgEtd0z69mPGmkp014d6ZY=",
               "rFjc3wG7lTZe43zeYTvPq8k4xdDEutCmIhI5dn4oCeE="
             ],


### PR DESCRIPTION
 `*.domain.com` will now pin `domain.com` and all its subdomains to the provided certificates.


This is sort of a breaking change if there were people relying on the undocumented (and divergent between platforms) behavior where on iOS `domain.com` would pin the subdomains too (on Android it would not)

closes #9 