### PR TITLE
fix: android builds failing because of incompatible kotlin version used by appmattus.certificatetransparency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -96,5 +96,5 @@ dependencies {
 
   // package-specific dependencies
   implementation("com.facebook.react:react-native:+")
-  implementation("com.appmattus.certificatetransparency:certificatetransparency-android:2.5+") // using `+` because minors are mostly automated updates of logs_list
+  implementation("com.appmattus.certificatetransparency:certificatetransparency-android:2.5.0")
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bam.tech/react-native-app-security",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Easily implement usual security measures in React Native Expo apps",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Fixes #15 by forcing vesion of com.appmattus.certificatetransparency:certificatetransparency-android to 2.5.0. A new version was released that was forcing kotlin 2.1.0 causing build issues for react native projects