### PR TITLE
Fix/alert above splashscreen ios

### DIFF
--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -1,7 +1,7 @@
 import { SafeKeyboardDetector } from "@bam.tech/react-native-app-security";
 import { useRouter } from "expo-router";
 import { useState } from "react";
-import { Button, Modal, Platform, StyleSheet, View } from "react-native";
+import { Alert, Button, Modal, Platform, StyleSheet, View } from "react-native";
 
 export default function App() {
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -11,6 +11,7 @@ export default function App() {
     <View style={styles.container}>
       <Modal visible={isModalVisible}>
         <View style={styles.modal}>
+          <Button title="show an alert" onPress={() => Alert.alert("Hello")} />
           <Button
             title="close modal"
             onPress={() => setIsModalVisible(false)}

--- a/ios/RNASAppLifecyleDelegate.swift
+++ b/ios/RNASAppLifecyleDelegate.swift
@@ -41,15 +41,3 @@ func isPreventRecentScreenshotsEnabled() -> Bool {
     return false
 }
 
-
-func getTopMostViewController() -> UIViewController {
-    // We want to display the overlay over any content currently presented, including modals
-    
-    var topController: UIViewController = UIApplication.shared.windows.first!.rootViewController!
-    
-    while (topController.presentedViewController != nil) {
-        topController = topController.presentedViewController!
-    }
-    
-    return topController
-}

--- a/ios/RNASAppLifecyleDelegate.swift
+++ b/ios/RNASAppLifecyleDelegate.swift
@@ -2,8 +2,13 @@ import ExpoModulesCore
 import UIKit
 
 public class RNASAppLifecycleDelegate: ExpoAppDelegateSubscriber {
-    private var launchScreenWindow: UIWindow?
-
+    private lazy var launchScreenWindow: UIWindow? = {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        let launchScreen = UIStoryboard(name: "SplashScreen", bundle: nil).instantiateInitialViewController()!
+        window.rootViewController = launchScreen
+        window.windowLevel = .alert + 2 // React Native alert uses .alert + 1
+        return window
+    }()
 
     public func applicationDidFinishLaunching(_ application: UIApplication) {
         if(!isPreventRecentScreenshotsEnabled()) {
@@ -20,19 +25,11 @@ public class RNASAppLifecycleDelegate: ExpoAppDelegateSubscriber {
         
         // https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background
         
-        let window = UIWindow(frame: UIScreen.main.bounds)
-       
-        let launchScreen = UIStoryboard(name: "SplashScreen", bundle: nil).instantiateInitialViewController()!
-        
-        window.rootViewController = launchScreen
-        window.windowLevel = .alert + 2 // React Native alert uses .alert + 1
-        window.makeKeyAndVisible()
-        self.launchScreenWindow = window
+        launchScreenWindow?.makeKeyAndVisible()
     }
         
     public func applicationDidBecomeActive(_ application: UIApplication) {
         launchScreenWindow?.isHidden = true
-        launchScreenWindow = nil
     }
 }
 

--- a/ios/RNASAppLifecyleDelegate.swift
+++ b/ios/RNASAppLifecyleDelegate.swift
@@ -2,7 +2,8 @@ import ExpoModulesCore
 import UIKit
 
 public class RNASAppLifecycleDelegate: ExpoAppDelegateSubscriber {
-    private var launchScreenViewController: UIViewController?
+    private var launchScreenWindow: UIWindow?
+
 
     public func applicationDidFinishLaunching(_ application: UIApplication) {
         if(!isPreventRecentScreenshotsEnabled()) {
@@ -18,18 +19,20 @@ public class RNASAppLifecycleDelegate: ExpoAppDelegateSubscriber {
         }
         
         // https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background
-                
-        if let launchScreen = UIStoryboard(name: "SplashScreen", bundle: nil).instantiateInitialViewController() {
-            launchScreen.modalPresentationStyle = .overFullScreen
-            getTopMostViewController().present(launchScreen, animated: false)
-            launchScreenViewController = launchScreen
-        }
+        
+        let window = UIWindow(frame: UIScreen.main.bounds)
+       
+        let launchScreen = UIStoryboard(name: "SplashScreen", bundle: nil).instantiateInitialViewController()!
+        
+        window.rootViewController = launchScreen
+        window.windowLevel = .alert + 2 // React Native alert uses .alert + 1
+        window.makeKeyAndVisible()
+        self.launchScreenWindow = window
     }
         
     public func applicationDidBecomeActive(_ application: UIApplication) {
-        launchScreenViewController?.dismiss(animated: false) {
-            self.launchScreenViewController = nil
-        }
+        launchScreenWindow?.isHidden = true
+        launchScreenWindow = nil
     }
 }
 


### PR DESCRIPTION
## Bug

React Native alerts were displayed above the splashscreen when preventSnapshot feature was activated.

This PR displays the native splashscreen in a window that has a windowLevel higher than the one used by React Native Alert.


| Before | After |
| -- |  -- |
| https://github.com/user-attachments/assets/3a6256aa-ff9c-489b-86d9-35537551fa9e| https://github.com/user-attachments/assets/9e449ba3-8ffb-4e56-be7d-4fe210eaaf11|