### PR TITLE
Feat: disable default iOS URLCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - [Prevent "recent screenshots"](#prevent-recent-screenshots)
     - [Configuration](#configuration-2)
   - [Safe Keyboard Detector](#safe-keyboard-detector)
+  - [[EXPERIMENTAL - iOS only] Disable Default Caching in `Cache.db`](#experimental---ios-only-disable-default-caching-in-cachedb)
 - [Contributing](#contributing)
 - [👉 About BAM](#-about-bam)
 
@@ -182,16 +183,37 @@ if (!isInDefaultSafeList) {
 SafeKeyboardDetector.showInputMethodPicker(); // can only be called on Android
 ```
 
-## [iOS only] Disable Default Caching in `Cache.db`
+## [EXPERIMENTAL - iOS only] Disable Default Caching in `Cache.db`
+> ⚠️ **DISCLAIMER:** This experimental feature may impact app behavior. Use it at your own risk. Disabling caching can cause unexpected issues.  
+>  
+> **Possible side effects:**  
+> - Slower performance due to lack of cached responses  
+> - Higher network usage from repeated requests  
+> - Crashes in components expecting cached data  
+> - Features failing in offline mode
 
 > **🥷 Threat:** On iOS, every `NSURL` request may be cached by default in `Cache.db`, potentially storing sensitive data unless explicitly disabled. This can lead to unintentional data leaks.
 
 Mitigating this threat is achieved by:
 
+- Fully clearing the existing cache
 - Remove the cache by setting it to an empty cache:
 
 ```swift
 URLCache.shared = URLCache(memoryCapacity: 0, diskCapacity: 0, diskPath: nil)
+```
+### Configuration
+If you want to enable this functionality, it need to be enabled in the app configuration file (by default it's disabled)
+
+```jsonc
+[
+  "@bam.tech/react-native-app-security",
+  {
+    "disableCache": {
+      "ios": { "enabled": true },
+    }
+  }
+]
 ```
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -182,6 +182,18 @@ if (!isInDefaultSafeList) {
 SafeKeyboardDetector.showInputMethodPicker(); // can only be called on Android
 ```
 
+## [iOS only] Disable Default Caching in `Cache.db`
+
+> **🥷 Threat:** On iOS, every `NSURL` request may be cached by default in `Cache.db`, potentially storing sensitive data unless explicitly disabled. This can lead to unintentional data leaks.
+
+Mitigating this threat is achieved by:
+
+- Remove the cache by setting it to an empty cache:
+
+```swift
+URLCache.shared = URLCache(memoryCapacity: 0, diskCapacity: 0, diskPath: nil)
+```
+
 # Contributing
 
 Contributions are welcome. See the [Expo modules docs](https://docs.expo.dev/modules/get-started/) for information on how to build/run/develop on the project.

--- a/example/app.config.ts
+++ b/example/app.config.ts
@@ -49,6 +49,11 @@ const config: ExpoConfig = {
             enabled: true,
           },
         },
+        disableCache: {
+          ios: {
+            enabled: true,
+          },
+        },
       },
     ],
     "expo-router",

--- a/example/app/index.tsx
+++ b/example/app/index.tsx
@@ -41,6 +41,9 @@ export default function App() {
           onPress={() => SafeKeyboardDetector.showInputMethodPicker()}
         />
       ) : null}
+      {Platform.OS === "ios" ? (
+        <Button title="fake login route call" onPress={callLoginRoute} />
+      ) : null}
     </View>
   );
 }
@@ -113,4 +116,19 @@ const checkIsKeyboardSafe = () => {
     SafeKeyboardDetector.getCurrentInputMethodInfo().isInDefaultSafeList;
   console.log(SafeKeyboardDetector.getCurrentInputMethodInfo().inputMethodId);
   console.warn("is Keyboard safe", isKeyboardSafe);
+};
+
+const callLoginRoute = async () => {
+  try {
+    await fetch("http://localhost:8081/login", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email: "example@myMail.com",
+        password: "a super strong password",
+      }),
+    });
+  } catch (error) {}
 };

--- a/ios/RNASAppLifecyleDelegate.swift
+++ b/ios/RNASAppLifecyleDelegate.swift
@@ -14,8 +14,15 @@ public class RNASAppLifecycleDelegate: ExpoAppDelegateSubscriber {
         if(isPreventRecentScreenshotsEnabled()) {
             application.ignoreSnapshotOnNextApplicationLaunch()
         }
-    
+
+        clearAndDisableCache()
+
         return true
+    }
+
+    private func clearAndDisableCache() {
+        URLCache.shared.removeAllCachedResponses()
+        URLCache.shared = URLCache(memoryCapacity: 0, diskCapacity: 0, diskPath: nil)
     }
     
     public func applicationWillResignActive(_ application: UIApplication) {

--- a/ios/RNASAppLifecyleDelegate.swift
+++ b/ios/RNASAppLifecyleDelegate.swift
@@ -10,12 +10,12 @@ public class RNASAppLifecycleDelegate: ExpoAppDelegateSubscriber {
         return window
     }()
 
-    public func applicationDidFinishLaunching(_ application: UIApplication) {
-        if(!isPreventRecentScreenshotsEnabled()) {
-            return
+    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        if(isPreventRecentScreenshotsEnabled()) {
+            application.ignoreSnapshotOnNextApplicationLaunch()
         }
-        
-        application.ignoreSnapshotOnNextApplicationLaunch()
+    
+        return true
     }
     
     public func applicationWillResignActive(_ application: UIApplication) {

--- a/ios/RNASAppLifecyleDelegate.swift
+++ b/ios/RNASAppLifecyleDelegate.swift
@@ -15,7 +15,10 @@ public class RNASAppLifecycleDelegate: ExpoAppDelegateSubscriber {
             application.ignoreSnapshotOnNextApplicationLaunch()
         }
 
-        clearAndDisableCache()
+        if(isDisablingCacheEnabled()){
+            clearAndDisableCache()
+        }
+
 
         return true
     }
@@ -48,3 +51,9 @@ func isPreventRecentScreenshotsEnabled() -> Bool {
     return false
 }
 
+func isDisablingCacheEnabled() -> Bool {
+    if let value = Bundle.main.object(forInfoDictionaryKey: "RNAS_DISABLE_CACHE") as? Bool {
+        return value
+    }
+    return false
+}

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -1,5 +1,6 @@
 import { ConfigPlugin } from "@expo/config-plugins";
 import { RNASConfig } from "./types";
+import withDisableCache from "./withDisableCache";
 import withpreventRecentScreenshots from "./withPreventRecentScreenshots";
 import withSSLPinning from "./withSSLPinning";
 
@@ -7,6 +8,7 @@ const withRNAS: ConfigPlugin<RNASConfig> = (config, props) => {
   config = withSSLPinning(config, props.sslPinning);
 
   config = withpreventRecentScreenshots(config, props.preventRecentScreenshots);
+  config = withDisableCache(config, props.preventRecentScreenshots);
 
   return config;
 };

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -8,7 +8,7 @@ const withRNAS: ConfigPlugin<RNASConfig> = (config, props) => {
   config = withSSLPinning(config, props.sslPinning);
 
   config = withpreventRecentScreenshots(config, props.preventRecentScreenshots);
-  config = withDisableCache(config, props.preventRecentScreenshots);
+  config = withDisableCache(config, props.disableCache);
 
   return config;
 };

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -6,4 +6,7 @@ export type RNASConfig = {
     ios?: { enabled: boolean };
     android?: { enabled: boolean };
   };
+  disableCache?: {
+    ios?: { enabled: boolean };
+  };
 };

--- a/plugin/src/withDisableCache.ts
+++ b/plugin/src/withDisableCache.ts
@@ -1,0 +1,25 @@
+import { ConfigPlugin, withInfoPlist } from "@expo/config-plugins";
+import { RNASConfig } from "./types";
+
+type Props = RNASConfig["preventRecentScreenshots"];
+
+const withDisableCache: ConfigPlugin<Props> = (config, props) => {
+  config = withInfoPlist(config, (config) => {
+    const infoPlist = config.modResults;
+
+    const isEnabled = props?.ios?.enabled ?? false;
+
+    if (!isEnabled) {
+      delete infoPlist.RNAS_DISABLE_CACHE;
+      return config;
+    }
+
+    infoPlist.RNAS_DISABLE_CACHE = true;
+
+    return config;
+  });
+
+  return config;
+};
+
+export default withDisableCache;


### PR DESCRIPTION
## What is the problem
On iOS, each request is cached in plain text within the app’s file system. A malicious user with root access could access this cache and extract sensitive data, such as credentials from a login endpoint.
 [More details on this article](https://medium.com/@mehran.kmlf/guarding-your-apps-secrets-the-hidden-dangers-of-cache-db-in-ios-f3f07d5febed)

## Proposal
Deactivate the URLCache and clear the existing cache
=> **Will it break things ?** On react native app, caching is mainly done on the JS side, this native cache does not seem to be used

## How to reproduce
- Launch your app
- Open the files associated to this app (for example using `open $(xcrun simctl get_app_container booted <your.bundle.id> data)`)
- Go to `Library/Caches/<your.bundle.id>`
- Open the `Cache.db`

<table>
	<thead>
	    <tr>
	      <th scope="col">Before</th>
	      <th scope="col">After</th>
	    </tr>
  	</thead>
<tbody>
 <tr>
<td>

https://github.com/user-attachments/assets/5c8c6894-08d5-49e7-8a66-a95de3cb4d94



</td >
<td>


https://github.com/user-attachments/assets/1f4ea1dd-e885-488f-b0d0-5a5d76313b06



</td >
</tr>
</tbody>
</table>

# TODO
Blocking the merge:
- [x] add a flag to enable/disable the functionality (disable by default)
- [x] complete README with an `Experimental` tag

To go further:
- [ ] investigate more deeply the full impact of fully disabling the cache (webview, assets, ...)