### PR TITLE
fix: fix release workflow broken since yarn 4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
         run: |
           npm config set --global //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
 
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable
+
       - name: Install dependencies
         run: yarn --frozen-lockfile
 


### PR DESCRIPTION
Fix the workflow to use corepack since the upgrade of yarn to v4