### PR TITLE
Fix(preventScreenshot): fix logic on iOS

### DIFF
--- a/ios/RNASAppLifecyleDelegate.swift
+++ b/ios/RNASAppLifecyleDelegate.swift
@@ -2,43 +2,64 @@ import ExpoModulesCore
 import UIKit
 
 public class RNASAppLifecycleDelegate: ExpoAppDelegateSubscriber {
+    private var becomeActiveObserver: NSObjectProtocol?
+
     private lazy var launchScreenWindow: UIWindow? = {
         let window = UIWindow(frame: UIScreen.main.bounds)
         let launchScreen = UIStoryboard(name: "SplashScreen", bundle: nil).instantiateInitialViewController()!
         window.rootViewController = launchScreen
         window.windowLevel = .alert + 2 // React Native alert uses .alert + 1
+        _ = launchScreen.view // Force view load so it renders correctly on first show
         return window
     }()
 
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         if(isPreventRecentScreenshotsEnabled()) {
             application.ignoreSnapshotOnNextApplicationLaunch()
+
+            // Subscribe directly to UIKit's notification instead of relying solely on the
+            // Expo delegate chain, which can delay or drop didBecomeActive during launch.
+            becomeActiveObserver = NotificationCenter.default.addObserver(
+                forName: UIApplication.didBecomeActiveNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.launchScreenWindow?.isHidden = true
+            }
         }
 
         if(isDisablingCacheEnabled()){
             clearAndDisableCache()
         }
 
-
         return true
+    }
+
+    deinit {
+        if let observer = becomeActiveObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
 
     private func clearAndDisableCache() {
         URLCache.shared.removeAllCachedResponses()
         URLCache.shared = URLCache(memoryCapacity: 0, diskCapacity: 0, diskPath: nil)
     }
-    
+
     public func applicationWillResignActive(_ application: UIApplication) {
         if(!isPreventRecentScreenshotsEnabled()) {
             return
         }
-        
+
         // https://developer.apple.com/documentation/uikit/app_and_environment/scenes/preparing_your_ui_to_run_in_the_background
-        
-        launchScreenWindow?.makeKeyAndVisible()
+        // Use isHidden instead of makeKeyAndVisible to avoid stealing key window status,
+        // which can cause cascading willResignActive events and a stuck visible overlay.
+        launchScreenWindow?.isHidden = false
     }
-        
+
     public func applicationDidBecomeActive(_ application: UIApplication) {
+        // Belt-and-suspenders: also hide via delegate in case the notification observer
+        // wasn't set up in time (e.g. preventRecentScreenshots disabled then re-enabled).
         launchScreenWindow?.isHidden = true
     }
 }


### PR DESCRIPTION
**Bug fixed** : Opening Control Center during app launch causes the screenshot prevention overlay to get stuck visible on iOS. The overlay remains on screen while the app is fully active, producing a white screen over the app content. Subsequent background/foreground transitions are also affected.

  **File**: RNASAppLifecyleDelegate.swift


  Change: Added `private var becomeActiveObserver: NSObjectProtocol?`
  Why: Holds a reference to the NotificationCenter observer for proper cleanup in deinit
  ────────────────────────────────────────
  Change: Added `_ = launchScreen.view` in the lazy `launchScreenWindow` initializer
  Why: Forces the storyboard view controller to load its view eagerly, so the overlay renders its content immediately instead of showing a blank white window on first display
  ────────────────────────────────────────
  Change: In `didFinishLaunchingWithOptions`: subscribe to `UIApplication.didBecomeActiveNotification` via NotificationCenter
  Why: This notification is posted directly by UIKit at the OS level, independently of Expo's delegate chain. It fires reliably when the app becomes active even during launch, where the delegate method is dropped
  ────────────────────────────────────────
  Change: Added deinit to remove the NotificationCenter observer
  Why: Prevents a memory leak if the delegate is ever deallocated
  ────────────────────────────────────────
  Change: Replaced `launchScreenWindow?.makeKeyAndVisible()` with `launchScreenWindow?.isHidden = false` in `applicationWillResignActive`
  Why: `makeKeyAndVisible()` steals key window status from the main app window, which triggers cascading `willResignActive` events from internal app activity, causing the overlay to re-appear unexpectedly. The window's .alert + 2 level already guarantees it appears on top without needing key window status
  ────────────────────────────────────────
  Change: Added a comment to `applicationDidBecomeActive`
  Why: Kept as belt-and-suspenders fallback in case the NotificationCenter observer is not set up (e.g. preventRecentScreenshots is toggled at runtime)