### PR TITLE
Fix(CertificateTransparency): remove deprecated certificate transparency logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,8 @@
       - [Pinning subdomains](#pinning-subdomains)
     - [Generating the public key hashes](#generating-the-public-key-hashes)
     - [Testing](#testing)
-  - [Certificate transparency](#certificate-transparency)
-    - [Configuration](#configuration-1)
   - [Prevent "recent screenshots"](#prevent-recent-screenshots)
-    - [Configuration](#configuration-2)
+    - [Configuration](#configuration-1)
   - [Safe Keyboard Detector](#safe-keyboard-detector)
   - [[EXPERIMENTAL - iOS only] Disable Default Caching in `Cache.db`](#experimental---ios-only-disable-default-caching-in-cachedb)
 - [Contributing](#contributing)
@@ -126,21 +124,6 @@ To test that SSL pinning is working as expected, you can:
 
 - break (change) a certificate and check that the connection fails _(don't forget to `yarn expo prebuild` then `yarn ios` or `yarn android` to rebuild the app)_
 - set up a proxy (we love [Proxyman](https://proxyman.io)) and check that the connection fails
-
-## Certificate transparency
-
-> **🥷 What's the threat?** Compromised certificate authorities. [More details](https://certificate.transparency.dev)
-
-
-Certificate Transparency (CT) is a mechanism that ensures that certificates are publicly logged in auditable, append-only logs. Rather than directly verifying log inclusion, CT relies on Signed Certificate Timestamps (SCTs), which provide a cryptographic proof that a certificate has been submitted to a trusted log.
-
-- On iOS, [Certificate Transparency is enforced by default](https://developer.apple.com/documentation/ios-ipados-release-notes/ios-12_1_1-release-notes) since _iOS 12.1.1_. The system validates that certificates comply with CT requirements, including the presence of valid Signed Certificate Timestamps (SCTs) issued by trusted logs.
-
-- On Android, this package enables Certificate Transparency for _Android >= 8.0_ using [appmattus/certificatetransparency](https://github.com/appmattus/certificatetransparency). It installs a network interceptor that validates, for each request, that the server certificate contains valid SCTs issued by trusted CT logs. This verification relies on a static list of trusted logs (`log_list.json`) bundled at build time, with no dynamic updates at runtime.
-
-### Configuration
-
-None, enabled by default.
 
 ## Prevent "recent screenshots"
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -97,17 +97,4 @@ dependencies {
   // package-specific dependencies
   implementation("com.facebook.react:react-native:+")
 
-  /*
-   * See https://github.com/bamlab/react-native-app-security/issues/15
-   * appmattus.certificatetransparency >= 2.5.75 is built with Kotlin 2.
-   * However, React Native projects < 0.77 are usually built with Kotlin 1.
-   * Avoid failing builds, at the cost of not getting the latest CT info
-   * TODO: Remove this when React Native 0.76 is EOL
-   */
-  def certificateTransparencyVersion = "2.8+"
-  if (getKotlinVersion().startsWith("1.")) {
-    certificateTransparencyVersion = "2.5.74"
-  }
-
-  implementation("com.appmattus.certificatetransparency:certificatetransparency:${certificateTransparencyVersion}")
 }

--- a/android/src/main/java/tech/bam/rnas/HttpClientOverride.kt
+++ b/android/src/main/java/tech/bam/rnas/HttpClientOverride.kt
@@ -1,13 +1,10 @@
 package tech.bam.rnas
 
-import android.os.Build
 import com.facebook.react.modules.network.OkHttpClientFactory;
 import com.facebook.react.modules.network.OkHttpClientProvider;
 
 import okhttp3.CertificatePinner;
 import okhttp3.OkHttpClient;
-
-import com.appmattus.certificatetransparency.CTInterceptorBuilder
 
 import org.json.JSONObject
 
@@ -29,16 +26,6 @@ public class SSLPinning : OkHttpClientFactory {
     }
 
     clientBuilder.certificatePinner(certificatePinnerBuilder.build())
-
-    // -- Certificate Transparency --
-
-    /*
-     * The library for certificate transparency does not support Android sdk version < 26 (Android 8.0) without setting up "desugaring"
-     * See more : https://github.com/appmattus/certificatetransparency#getting-started
-     */
-    if (Build.VERSION.SDK_INT >= 26) {
-      clientBuilder.addNetworkInterceptor(CTInterceptorBuilder().build())
-    }
 
     return clientBuilder.build()
   }


### PR DESCRIPTION
Google will not allow certificate transparency from third parties library so we deprecate this part of the code for Android.

SSLPinning is untouched.